### PR TITLE
feat: パッシブアビリティ対象拡張機能を実装

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -43,6 +43,18 @@ def keyword_map(k: str) -> str:
     }.get(k, k)
 
 
+# ---------------- target resolution constants ----------------
+TARGET_ZONES = [
+    "Field",
+    "Environment", 
+    "Counter",
+    "Hand",
+    "Deck",
+    "Graveyard",
+    "ExileZone",
+    "DamageZone"
+]
+
 # ---------------- target resolution ----------------
 def resolve_targets(src: Dict[str, Any], action: Dict[str, Any], item: Dict[str, Any]) -> List[Dict]:
     # 1) selectionKey 優先
@@ -95,7 +107,39 @@ def get_target_cards(src: Dict, action: Dict, item: Dict) -> List[Dict]:
         return [c for c in cards if c["ownerId"] == oid and c["zone"] == "Hand"]
     if target == "PlayerDeckTop":
         return [c for c in cards if c["ownerId"] == owner and c["zone"] == "Deck"][: int(action.get("value", 1))]
-    # … 他も同様に…
+    # パッシブアビリティ対象拡張: Environment ゾーン
+    if target == "Environment":
+        return [c for c in cards if c["zone"] == "Environment"]
+    if target == "PlayerEnvironment":
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "Environment"]
+    if target == "EnemyEnvironment":
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "Environment"]
+    # パッシブアビリティ対象拡張: Counter ゾーン
+    if target == "Counter":
+        return [c for c in cards if c["zone"] == "Counter"]
+    if target == "PlayerCounter":
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "Counter"]
+    if target == "EnemyCounter":
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "Counter"]
+    # パッシブアビリティ対象拡張: その他のゾーン
+    if target == "PlayerGraveyard":
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "Graveyard"]
+    if target == "EnemyGraveyard":
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "Graveyard"]
+    if target == "AllGraveyard":
+        return [c for c in cards if c["zone"] == "Graveyard"]
+    if target == "PlayerExileZone":
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "ExileZone"]
+    if target == "EnemyExileZone":
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "ExileZone"]
+    if target == "AllExileZone":
+        return [c for c in cards if c["zone"] == "ExileZone"]
+    if target == "PlayerDamageZone":
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "DamageZone"]
+    if target == "EnemyDamageZone":
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "DamageZone"]
+    if target == "AllDamageZone":
+        return [c for c in cards if c["zone"] == "DamageZone"]
 
     return []
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -7,7 +7,7 @@ from importlib import import_module
 # --- 自前モジュール -----------------------------------------
 from helper import (
     add_status, add_temp_status, keyword_map, d, resolve_targets,
-    DecimalEncoder,
+    DecimalEncoder, TARGET_ZONES,
 )
 from action_registry import get as get_handler  # ここがディスパッチ
 import actions  # noqa  (サイドエフェクトで handler 登録)
@@ -129,15 +129,16 @@ def apply_action(card, act, item, owner_id):
 def evaluate_condition(cond: str, card: dict, item: dict) -> bool:
     """
     条件式をパースして真偽を返す。
-    今回は PlayerTurnAndSelfFieldCount==N のみ対応例。
+    拡張されたパッシブアビリティ対象用の条件評価機能。
     """
     if not cond:
         return True
-    # 自分ターンかつ自分フィールド枚数 == N
+    
     print(f"Evaluating condition: {cond} for card {card['id']}")
+    
+    # 自分ターンかつ自分フィールド枚数 == N
     if cond.startswith("PlayerTurnAndSelfFieldCount=="):
         try:
-            print(f"  Parsing condition: {cond}")
             n = int(cond.split("==",1)[1])
         except ValueError:
             print(f"  Invalid condition format: {cond}")
@@ -145,54 +146,196 @@ def evaluate_condition(cond: str, card: dict, item: dict) -> bool:
         return (item["turnPlayerId"] == card["ownerId"] and
                 sum(1 for c in item["cards"]
                     if c["ownerId"] == card["ownerId"] and c["zone"] == "Field") == n)
+    
+    # 敵フィールド枚数の条件評価
+    if cond.startswith("EnemyFieldCount"):
+        try:
+            if ">=" in cond:
+                n = int(cond.split(">=",1)[1])
+                enemy_field_count = sum(1 for c in item["cards"]
+                                      if c["ownerId"] != card["ownerId"] and c["zone"] == "Field")
+                return enemy_field_count >= n
+            elif "==" in cond:
+                n = int(cond.split("==",1)[1])
+                enemy_field_count = sum(1 for c in item["cards"]
+                                      if c["ownerId"] != card["ownerId"] and c["zone"] == "Field")
+                return enemy_field_count == n
+            elif "<=" in cond:
+                n = int(cond.split("<=",1)[1])
+                enemy_field_count = sum(1 for c in item["cards"]
+                                      if c["ownerId"] != card["ownerId"] and c["zone"] == "Field")
+                return enemy_field_count <= n
+        except ValueError:
+            print(f"  Invalid condition format: {cond}")
+            return False
+    
+    # 自分フィールド枚数の条件評価
+    if cond.startswith("PlayerFieldCount"):
+        try:
+            if ">=" in cond:
+                n = int(cond.split(">=",1)[1])
+                player_field_count = sum(1 for c in item["cards"]
+                                       if c["ownerId"] == card["ownerId"] and c["zone"] == "Field")
+                return player_field_count >= n
+            elif "==" in cond:
+                n = int(cond.split("==",1)[1])
+                player_field_count = sum(1 for c in item["cards"]
+                                       if c["ownerId"] == card["ownerId"] and c["zone"] == "Field")
+                return player_field_count == n
+            elif "<=" in cond:
+                n = int(cond.split("<=",1)[1])
+                player_field_count = sum(1 for c in item["cards"]
+                                       if c["ownerId"] == card["ownerId"] and c["zone"] == "Field")
+                return player_field_count <= n
+        except ValueError:
+            print(f"  Invalid condition format: {cond}")
+            return False
+    
+    # Environment ゾーンの条件評価
+    if cond.startswith("EnvironmentCount"):
+        try:
+            if ">=" in cond:
+                n = int(cond.split(">=",1)[1])
+                env_count = sum(1 for c in item["cards"] if c["zone"] == "Environment")
+                return env_count >= n
+            elif "==" in cond:
+                n = int(cond.split("==",1)[1])
+                env_count = sum(1 for c in item["cards"] if c["zone"] == "Environment")
+                return env_count == n
+            elif "<=" in cond:
+                n = int(cond.split("<=",1)[1])
+                env_count = sum(1 for c in item["cards"] if c["zone"] == "Environment")
+                return env_count <= n
+        except ValueError:
+            print(f"  Invalid condition format: {cond}")
+            return False
+    
+    # ターン数の条件評価
+    if cond.startswith("TurnCount"):
+        try:
+            turn_count = item.get("turnCount", 0)
+            if ">=" in cond:
+                n = int(cond.split(">=",1)[1])
+                return turn_count >= n
+            elif "==" in cond:
+                n = int(cond.split("==",1)[1])
+                return turn_count == n
+            elif "<=" in cond:
+                n = int(cond.split("<=",1)[1])
+                return turn_count <= n
+        except ValueError:
+            print(f"  Invalid condition format: {cond}")
+            return False
+    
     # 他の条件式が増えたらここに追加…
+    print(f"  Unknown condition: {cond}")
     return False
 
 # ----------------------
 #  リーダーのパッシブ オーラ更新
 # ----------------------
 def refresh_passive_auras(item, events):
+    """
+    全プレイヤーのリーダーパッシブ効果を再評価し、適用/解除を行う。
+    拡張されたゾーンフィルタリングに対応。
+    """
     for p in item["players"]:
-        leader_def = get_leader_def(p["leaderId"])
-        print(f"Processing leader {p['leaderId']} for player {p['id']}, leader_def: {leader_def}")
-        if not leader_def:
-            continue
+        _process_leader_passive_effects(p, item, events)
 
-        turn_cnt = item.get("turnCount", 0)
-        stage_idx = get_stage_index(turn_cnt)
-        stages = leader_def.get("evolutionStages", [])
-        print(f"  Evolution stage index: {stage_idx} (turn {turn_cnt})")
-        if stage_idx >= len(stages):
-            continue
-        stage_def = stages[stage_idx]
 
-        # すべてのパッシブ効果を評価
-        print(f"  Evaluating passive effects for stage {stage_idx}")
-        for eff in stage_def.get("passiveEffects", []):
-            print(f"    Evaluating effect: {eff}")
-            cond = eff.get("condition", "")
-            # ここで ownerId を持つダミーカードを渡す
-            leader_card = {"id": p["leaderId"], "ownerId": p["id"]}
-            if evaluate_condition(cond, leader_card, item):
-                # 条件成立→付与
-                print(f"    Condition met, applying effect: {eff}")
-                apply_passive_effect(eff, p, item, events)
-            else:
-                # 条件不成立→解除
-                print(f"    Condition not met, clearing effect: {eff}")
-                clear_passive_from_targets(eff, p, item, events)
+def _process_leader_passive_effects(player, item, events):
+    """
+    単一プレイヤーのリーダーパッシブ効果を処理する。
+    """
+    leader_def = get_leader_def(player["leaderId"])
+    print(f"Processing leader {player['leaderId']} for player {player['id']}, leader_def: {leader_def}")
+    if not leader_def:
+        return
+
+    turn_cnt = item.get("turnCount", 0)
+    stage_idx = get_stage_index(turn_cnt)
+    stages = leader_def.get("evolutionStages", [])
+    print(f"  Evolution stage index: {stage_idx} (turn {turn_cnt})")
+    if stage_idx >= len(stages):
+        return
+    stage_def = stages[stage_idx]
+
+    # すべてのパッシブ効果を評価
+    print(f"  Evaluating passive effects for stage {stage_idx}")
+    for eff in stage_def.get("passiveEffects", []):
+        print(f"    Evaluating effect: {eff}")
+        _evaluate_and_apply_passive_effect(eff, player, item, events)
+
+
+def _evaluate_and_apply_passive_effect(effect, player, item, events):
+    """
+    単一パッシブ効果の条件評価と適用/解除を行う。
+    """
+    cond = effect.get("condition", "")
+    # ここで ownerId を持つダミーカードを渡す
+    leader_card = {"id": player["leaderId"], "ownerId": player["id"]}
+    
+    if evaluate_condition(cond, leader_card, item):
+        # 条件成立→付与
+        print(f"    Condition met, applying effect: {effect}")
+        apply_passive_effect(effect, player, item, events)
+    else:
+        # 条件不成立→解除
+        print(f"    Condition not met, clearing effect: {effect}")
+        clear_passive_from_targets(effect, player, item, events)
+
+
+def _get_target_zones_from_action(action):
+    """
+    アクションの target 設定から対象となるゾーンを取得する。
+    """
+    target = action.get("target", "")
+    if "Field" in target:
+        return ["Field"]
+    elif "Environment" in target:
+        return ["Environment"]
+    elif "Counter" in target:
+        return ["Counter"]
+    elif "Hand" in target:
+        return ["Hand"]
+    elif "Graveyard" in target:
+        return ["Graveyard"]
+    elif "ExileZone" in target:
+        return ["ExileZone"]
+    elif "DamageZone" in target:
+        return ["DamageZone"]
+    elif "Deck" in target:
+        return ["Deck"]
+    else:
+        return ["Unknown"]
 
 
 def apply_passive_effect(eff, player, item, events):
+    """
+    パッシブ効果を対象カードに適用する。
+    拡張されたゾーンフィルタリングに対応。
+    """
     dummy = {"id": player["leaderId"], "ownerId": player["id"]}
+    
     for act in eff.get("actions", []):
-        # 対象カード取得
+        # 対象カード取得（拡張されたゾーン対応）
         targets = resolve_targets(dummy, act, item)
-        # ログ
+        target_zones = _get_target_zones_from_action(act)
+        
+        print(f"      Applying passive effect to {len(targets)} targets in zones: {target_zones}")
+        print(f"      Target IDs: {[t['id'] for t in targets]}")
+        
+        # アビリティ発動ログ
         events.append({
             "type": "AbilityActivated",
-            "payload": {"sourceCardId": dummy["id"], "trigger": eff.get("trigger", "Passive")}
+            "payload": {
+                "sourceCardId": dummy["id"], 
+                "trigger": eff.get("trigger", "Passive"),
+                "targetZones": target_zones,
+                "targetCount": len(targets)
+            }
         })
+        
         # 実際に付与
         for tgt in targets:
             events.extend(apply_action(tgt, act, item, player["id"]))
@@ -201,50 +344,69 @@ def apply_passive_effect(eff, player, item, events):
 def clear_passive_from_targets(eff, player, item, events):
     """
     以前に付与したパッシブオーラを外す。
-    eff: passiveEffects の M っぽい dict
-    player: players リストの要素 (M っぽい dict)
+    拡張されたゾーンフィルタリングに対応。
     """
     dummy = {"id": player["leaderId"], "ownerId": player["id"]}
+    
     for act in eff.get("actions", []):
         k = act.get("keyword") or act["type"].replace("Aura","")
         k_mapped = keyword_map(k)
         dur = int(act.get("duration", -1))
-        # 対象カード
+        
+        # 対象カード取得（拡張されたゾーン対応）
         targets = resolve_targets(dummy, act, item)
+        target_zones = _get_target_zones_from_action(act)
+        
+        print(f"      Clearing passive effect from {len(targets)} targets in zones: {target_zones}")
+        print(f"      Target IDs: {[t['id'] for t in targets]}")
 
         for tgt in targets:
             # 一時ステータスをクリア
-            before = len(tgt.get("tempStatuses", []))
-            tgt["tempStatuses"] = [
-                s for s in tgt.get("tempStatuses", [])
-                if not (s["key"] == k_mapped and s["sourceId"] == dummy["id"])
-            ]
-            if len(tgt.get("tempStatuses", [])) < before:
-                events.append({
-                    "type": "BattleBuffRemoved",
-                    "payload": {
-                        "cardId": tgt["id"],
-                        "keyword": k,
-                        "sourceCardId": dummy["id"]
-                    }
-                })
-
+            _clear_temp_statuses(tgt, k_mapped, dummy["id"], k, events)
+            
             # 恒常ステータス（dur == -1）もクリア
             if dur == -1:
-                before = len(tgt.get("statuses", []))
-                tgt["statuses"] = [
-                    v for v in tgt.get("statuses", [])
-                    if not (v["key"] == k_mapped and v.get("sourceId") == dummy["id"])
-                ]
-                if len(tgt.get("statuses", [])) < before:
-                    events.append({
-                        "type": "StatusRemoved",
-                        "payload": {
-                            "cardId": tgt["id"],
-                            "keyword": k,
-                            "sourceCardId": dummy["id"]
-                        }
-                    })
+                _clear_permanent_statuses(tgt, k_mapped, dummy["id"], k, events)
+
+
+def _clear_temp_statuses(target, keyword_mapped, source_id, keyword, events):
+    """
+    対象カードから一時ステータスを削除する。
+    """
+    before = len(target.get("tempStatuses", []))
+    target["tempStatuses"] = [
+        s for s in target.get("tempStatuses", [])
+        if not (s["key"] == keyword_mapped and s["sourceId"] == source_id)
+    ]
+    if len(target.get("tempStatuses", [])) < before:
+        events.append({
+            "type": "BattleBuffRemoved",
+            "payload": {
+                "cardId": target["id"],
+                "keyword": keyword,
+                "sourceCardId": source_id
+            }
+        })
+
+
+def _clear_permanent_statuses(target, keyword_mapped, source_id, keyword, events):
+    """
+    対象カードから恒常ステータスを削除する。
+    """
+    before = len(target.get("statuses", []))
+    target["statuses"] = [
+        v for v in target.get("statuses", [])
+        if not (v["key"] == keyword_mapped and v.get("sourceId") == source_id)
+    ]
+    if len(target.get("statuses", [])) < before:
+        events.append({
+            "type": "StatusRemoved",
+            "payload": {
+                "cardId": target["id"],
+                "keyword": keyword,
+                "sourceCardId": source_id
+            }
+        })
 
 # ---------- Phase helper -------------------------------------
 

--- a/test_passive_extensions.py
+++ b/test_passive_extensions.py
@@ -1,0 +1,103 @@
+# test_passive_extensions.py
+# 簡単なテストケース例 - パッシブアビリティ対象拡張の動作確認
+
+from lambda_function import evaluate_condition, _get_target_zones_from_action
+from helper import get_target_cards, TARGET_ZONES
+
+def test_zone_constants():
+    """対象ゾーンリストの定数定義テスト"""
+    expected_zones = [
+        "Field", "Environment", "Counter", "Hand", 
+        "Deck", "Graveyard", "ExileZone", "DamageZone"
+    ]
+    assert TARGET_ZONES == expected_zones
+    print("✓ TARGET_ZONES constant defined correctly")
+
+def test_environment_targeting():
+    """Environmentゾーンのターゲティングテスト"""
+    # テストデータ
+    src = {"id": "leader1", "ownerId": "player1"}
+    action = {"target": "Environment"}
+    item = {
+        "cards": [
+            {"id": "card1", "ownerId": "player1", "zone": "Field"},
+            {"id": "card2", "ownerId": "player1", "zone": "Environment"},
+            {"id": "card3", "ownerId": "player2", "zone": "Environment"},
+        ]
+    }
+    
+    targets = get_target_cards(src, action, item)
+    target_ids = [t["id"] for t in targets]
+    
+    expected = ["card2", "card3"]
+    assert target_ids == expected
+    print("✓ Environment zone targeting works correctly")
+
+def test_counter_targeting():
+    """Counterゾーンのターゲティングテスト"""
+    src = {"id": "leader1", "ownerId": "player1"}
+    action = {"target": "PlayerCounter"}
+    item = {
+        "cards": [
+            {"id": "card1", "ownerId": "player1", "zone": "Counter"},
+            {"id": "card2", "ownerId": "player2", "zone": "Counter"},
+        ]
+    }
+    
+    targets = get_target_cards(src, action, item)
+    target_ids = [t["id"] for t in targets]
+    
+    expected = ["card1"]
+    assert target_ids == expected
+    print("✓ Counter zone targeting works correctly")
+
+def test_extended_conditions():
+    """拡張された条件評価のテスト"""
+    card = {"id": "leader1", "ownerId": "player1"}
+    item = {
+        "cards": [
+            {"id": "card1", "ownerId": "player1", "zone": "Field"},
+            {"id": "card2", "ownerId": "player2", "zone": "Field"},
+            {"id": "card3", "ownerId": "player2", "zone": "Field"},
+        ],
+        "turnCount": 5
+    }
+    
+    # EnemyFieldCount>=2 のテスト
+    result = evaluate_condition("EnemyFieldCount>=2", card, item)
+    assert result == True
+    print("✓ EnemyFieldCount>=2 condition works correctly")
+    
+    # TurnCount>=3 のテスト
+    result = evaluate_condition("TurnCount>=3", card, item)
+    assert result == True
+    print("✓ TurnCount>=3 condition works correctly")
+
+def test_zone_detection():
+    """ゾーン検出ヘルパーのテスト"""
+    actions = [
+        {"target": "Environment", "expected": ["Environment"]},
+        {"target": "PlayerField", "expected": ["Field"]},
+        {"target": "Counter", "expected": ["Counter"]},
+    ]
+    
+    for action_data in actions:
+        zones = _get_target_zones_from_action(action_data)
+        assert zones == action_data["expected"]
+    
+    print("✓ Zone detection helper works correctly")
+
+def run_all_tests():
+    """すべてのテストを実行"""
+    print("パッシブアビリティ対象拡張のテスト開始...")
+    
+    test_zone_constants()
+    test_environment_targeting()
+    test_counter_targeting()
+    test_extended_conditions()
+    test_zone_detection()
+    
+    print("✓ すべてのテストが成功しました！")
+
+if __name__ == "__main__":
+    run_all_tests()

--- a/test_passive_extensions.py
+++ b/test_passive_extensions.py
@@ -1,7 +1,7 @@
 # test_passive_extensions.py
 # 簡単なテストケース例 - パッシブアビリティ対象拡張の動作確認
 
-from lambda_function import evaluate_condition, _get_target_zones_from_action
+from lambda_function import evaluate_condition, _get_target_zones_from_action, _convert_to_battle_buff
 from helper import get_target_cards, TARGET_ZONES
 
 def test_zone_constants():
@@ -87,6 +87,80 @@ def test_zone_detection():
     
     print("✓ Zone detection helper works correctly")
 
+def test_battle_buff_conversion():
+    """アクションをbattle_buffに変換するテスト"""
+    # PowerAuraの変換テスト
+    power_aura_action = {
+        "type": "PowerAura",
+        "target": "PlayerField",
+        "value": 100,
+        "duration": 2
+    }
+    
+    converted = _convert_to_battle_buff(power_aura_action)
+    expected = {
+        "type": "BattleBuff",
+        "target": "PlayerField",
+        "keyword": "Power",
+        "value": 100,
+        "duration": 2
+    }
+    
+    assert converted == expected
+    print("✓ PowerAura to BattleBuff conversion works correctly")
+    
+    # DamageAuraの変換テスト
+    damage_aura_action = {
+        "type": "DamageAura",
+        "target": "EnemyField",
+        "value": 50
+    }
+    
+    converted = _convert_to_battle_buff(damage_aura_action)
+    expected = {
+        "type": "BattleBuff",
+        "target": "EnemyField",
+        "keyword": "Damage",
+        "value": 50,
+        "duration": -1  # パッシブ効果のデフォルト
+    }
+    
+    assert converted == expected
+    print("✓ DamageAura to BattleBuff conversion works correctly")
+    
+    # KeywordAuraの変換テスト
+    keyword_aura_action = {
+        "type": "KeywordAura",
+        "target": "Self",
+        "keyword": "Protect",
+        "value": 1
+    }
+    
+    converted = _convert_to_battle_buff(keyword_aura_action)
+    expected = {
+        "type": "BattleBuff",
+        "target": "Self",
+        "keyword": "Protect",
+        "value": 1,
+        "duration": -1
+    }
+    
+    assert converted == expected
+    print("✓ KeywordAura to BattleBuff conversion works correctly")
+    
+    # 既にbattle_buffの場合はそのまま
+    battle_buff_action = {
+        "type": "BattleBuff",
+        "target": "Self",
+        "keyword": "Power",
+        "value": 200,
+        "duration": 1
+    }
+    
+    converted = _convert_to_battle_buff(battle_buff_action)
+    assert converted == battle_buff_action
+    print("✓ Existing BattleBuff action remains unchanged")
+
 def run_all_tests():
     """すべてのテストを実行"""
     print("パッシブアビリティ対象拡張のテスト開始...")
@@ -96,6 +170,7 @@ def run_all_tests():
     test_counter_targeting()
     test_extended_conditions()
     test_zone_detection()
+    test_battle_buff_conversion()
     
     print("✓ すべてのテストが成功しました！")
 


### PR DESCRIPTION
- 対象ゾーンリストの定数定義 (TARGET_ZONES)
- Environment, Counter, Graveyard, ExileZone, DamageZone ゾーンのターゲティング対応
- 条件評価機能の拡張 (EnemyFieldCount, PlayerFieldCount, EnvironmentCount, TurnCount)
- refresh_passive_auras の単一責任の原則に従ったリファクタリング
- apply_passive_effect と clear_passive_from_targets の改良
- 詳細なログ出力とゾーン情報の追加
- テストケースの追加