### PR TITLE
fix: refresh_passive_auras の効果が保存されるよう put_item の順序を修正

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -602,8 +602,10 @@ def lambda_handler(event, context):
 
         evs=resolve(trig,item)
         
-        item["updatedAt"]=now_iso(); bump(item); table.put_item(Item=item)
+        item["updatedAt"]=now_iso()
+        bump(item)
         refresh_passive_auras(item, evs)
+        table.put_item(Item=item)
         return {"match":json.loads(json.dumps(item,cls=DecimalEncoder)),
                 "events":evs}
 
@@ -620,8 +622,10 @@ def lambda_handler(event, context):
               {"type":"OnEnterField","payload":{"cardId":cid}}]
         evs=resolve(trig,item)
         
-        item["updatedAt"]=now_iso(); bump(item); table.put_item(Item=item)
+        item["updatedAt"]=now_iso()
+        bump(item)
         refresh_passive_auras(item, evs)
+        table.put_item(Item=item)
         return {"match":json.loads(json.dumps(item,cls=DecimalEncoder)),
                 "events":evs}
 


### PR DESCRIPTION
moveCards と summonCard 関数で、refresh_passive_auras の実行後に table.put_item を呼び出すように修正しました。
これにより、パッシブアビリティによる状態変更がデータベースに適切に保存されるようになります。

Generated with [Claude Code](https://claude.ai/code)