### PR TITLE
fix: 安全なエラーハンドリングの実装

### DIFF
--- a/test_safe_error_handling.py
+++ b/test_safe_error_handling.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+安全なエラーハンドリングのテストファイル
+"""
+import json
+import boto3
+from moto import mock_dynamodb
+from decimal import Decimal
+from lambda_function import lambda_handler
+
+@mock_dynamodb
+def test_safe_error_handling():
+    """安全なエラーハンドリングのテスト"""
+    
+    # DynamoDB テーブルのセットアップ
+    dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
+    table = dynamodb.create_table(
+        TableName='BattleSync',
+        KeySchema=[
+            {'AttributeName': 'pk', 'KeyType': 'HASH'},
+            {'AttributeName': 'sk', 'KeyType': 'RANGE'}
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'pk', 'AttributeType': 'S'},
+            {'AttributeName': 'sk', 'AttributeType': 'S'}
+        ],
+        BillingMode='PAY_PER_REQUEST'
+    )
+    
+    # テスト用のマッチデータ
+    test_match = {
+        'pk': 'test-match-001',
+        'sk': 'STATE',
+        'cards': [
+            {
+                'id': 'card-001',
+                'zone': 'Field',
+                'ownerId': 'player-001',
+                'name': 'Test Card',
+                'power': Decimal('100'),
+                'damage': Decimal('50')
+            }
+        ],
+        'players': [
+            {
+                'id': 'player-001',
+                'name': 'Player 1',
+                'leaderId': 'leader-001'
+            },
+            {
+                'id': 'player-002',
+                'name': 'Player 2',
+                'leaderId': 'leader-002'
+            }
+        ],
+        'battleStep': 'BlockChoice',
+        'pendingBattle': {
+            'attackerId': 'card-001',
+            'attackerOwnerId': 'player-001'
+        },
+        'turnPlayerId': 'player-001',
+        'status': 'InProgress',
+        'updatedAt': '2024-01-01T00:00:00Z'
+    }
+    
+    table.put_item(Item=test_match)
+    
+    # テストケース 1: 無効な攻撃者ID
+    context = {'field': 'declareAttack', 'args': {'attackerId': 'invalid-card'}}
+    event = {'info': context, 'arguments': context['args']}
+    
+    result = lambda_handler(event, None)
+    
+    # エラーイベントが返されることを確認
+    assert 'events' in result
+    assert len(result['events']) == 1
+    assert result['events'][0]['type'] == 'InvalidAttacker'
+    assert 'message' in result['events'][0]['payload']
+    print("✓ 無効な攻撃者ID テスト通過")
+    
+    # テストケース 2: 攻撃者IDが存在しない
+    context = {'field': 'declareAttack', 'args': {}}
+    event = {'info': context, 'arguments': context['args']}
+    
+    result = lambda_handler(event, None)
+    
+    # 空のイベントが返されることを確認
+    assert 'events' in result
+    assert len(result['events']) == 0
+    print("✓ 攻撃者ID未指定 テスト通過")
+    
+    # テストケース 3: 無効なカードID (summonCard)
+    context = {'field': 'summonCard', 'args': {'cardId': 'invalid-card'}}
+    event = {'info': context, 'arguments': context['args']}
+    
+    result = lambda_handler(event, None)
+    
+    # エラーイベントが返されることを確認
+    assert 'events' in result
+    assert len(result['events']) == 1
+    assert result['events'][0]['type'] == 'CardNotFound'
+    assert 'message' in result['events'][0]['payload']
+    print("✓ 無効なカードID テスト通過")
+    
+    # テストケース 4: マッチIDが存在しない
+    context = {'field': 'getMatch', 'args': {}}
+    event = {'info': context, 'arguments': context['args']}
+    
+    result = lambda_handler(event, None)
+    
+    # エラーイベントが返されることを確認
+    assert 'events' in result
+    assert len(result['events']) == 1
+    assert result['events'][0]['type'] == 'MissingMatchId'
+    assert 'message' in result['events'][0]['payload']
+    print("✓ マッチID未指定 テスト通過")
+    
+    # テストケース 5: サポートされていないフィールド
+    context = {'field': 'unsupportedField', 'args': {'matchId': 'test-match-001'}}
+    event = {'info': context, 'arguments': context['args']}
+    
+    result = lambda_handler(event, None)
+    
+    # エラーイベントが返されることを確認
+    assert 'events' in result
+    assert len(result['events']) == 1
+    assert result['events'][0]['type'] == 'UnsupportedField'
+    assert 'message' in result['events'][0]['payload']
+    print("✓ サポート外フィールド テスト通過")
+    
+    print("\n🎉 すべてのテストが通過しました！")
+
+
+if __name__ == '__main__':
+    test_safe_error_handling()


### PR DESCRIPTION
## 概要

Invalid attacker エラーの安全な処理とパッシブアビリティの条件付き解除機能を実装しました。

## 主な変更点

- 全ての raise Exception を安全なエラーイベント返却に変更
- 攻撃者データの安全な処理を実装
- マッチデータの安全な検証を実装
- カードデータの安全な処理を実装
- バトルステップの安全な検証を実装
- テストファイルを追加してエラーハンドリングの動作確認

## 変更されたファイル

- `lambda_function.py` - 安全なエラーハンドリングの実装
- `test_safe_error_handling.py` - テストケースの追加

## テスト計画

- [ ] 各エラーハンドリングケースの動作確認
- [ ] パッシブアビリティの条件付き解除の確認
- [ ] ゲームの安全性とデータ整合性の確認

Closes #3

Generated with [Claude Code](https://claude.ai/code)