### PR TITLE
fix: Transform アクションの修正 - selectionKey 処理とログ追加

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -225,7 +225,18 @@ def apply_action(card, act, item, owner_id):
     logger.info(f"apply_action: card={card['id']} action={act['type']} owner={owner_id}")
 
     # ① 対象を解決する
-    targets = resolve_targets(card, act, item)
+    # Transform アクション専用の特別処理
+    if act["type"] == "Transform" and act.get("selectionKey"):
+        # selectionKey は変身先決定用なので、ターゲット解決から除外
+        act_for_targets = act.copy()
+        act_for_targets.pop("selectionKey", None)
+        if not act_for_targets.get("target"):
+            act_for_targets["target"] = "Self"  # デフォルトでSelfを対象
+        targets = resolve_targets(card, act_for_targets, item)
+        logger.info(f"  Transform action - excluded selectionKey from target resolution")
+    else:
+        targets = resolve_targets(card, act, item)
+    
     logger.info(f"  targets resolved: {[t['id'] for t in targets]}")
     events = []
 


### PR DESCRIPTION
Transform アクションの修正を実装しました。

## 変更内容

### lambda_function.py
- apply_action 関数に Transform 専用の特別処理を追加
- selectionKey は変身先決定用なので、ターゲット解決から除外
- デフォルトで Self を対象として設定

### actions/transform.py
- 詳細ログを追加
- ゾーン問題の修正：元ゾーンを保存してから使用

Closes #31

Generated with [Claude Code](https://claude.ai/code)