### PR TITLE
fix: ZoneType統一 - ExileZoneをExileに修正

### DIFF
--- a/action_registry.py
+++ b/action_registry.py
@@ -131,7 +131,7 @@ def _set_status(card, act, item, owner_id):
 _zone_map = {
     "Bounce": "Hand",
     "Discard": "Graveyard",
-    "Exile": "ExileZone",
+    "Exile": "Exile",
     "MoveField": "Field",
     "MoveDeck": "Deck",
     "MoveToDamageZone": "DamageZone",

--- a/actions/create_token.py
+++ b/actions/create_token.py
@@ -26,7 +26,7 @@ def handle_create_token(card, act, item, owner_id):
         "Graveyard": "Graveyard",
         "Environment": "Environment",
         "Counter": "Counter",
-        "ExileZone": "ExileZone",
+        "ExileZone": "Exile",
         "DamageZone": "DamageZone"
     }
     

--- a/actions/transform.py
+++ b/actions/transform.py
@@ -7,7 +7,7 @@ logger = logging.getLogger()
 
 def handle_transform(card, act, item, owner_id):
     """
-    Transform: 新しいトークンを生成し、元カードを ExileZone に移動
+    Transform: 新しいトークンを生成し、元カードを Exile に移動
     SelectOption の結果に基づいて変身先トークンを決定
     """
     logger.info(f"handle_transform: START - Transform処理開始 card={card['id']} owner={owner_id}")
@@ -23,7 +23,7 @@ def handle_transform(card, act, item, owner_id):
         logger.warning(f"handle_transform: No transform target found for card {card['id']}")
         return []
     
-    # 2. 元カード（Self）を ExileZone に移動
+    # 2. 元カード（Self）を Exile に移動
     exile_events = _move_card_to_exile(card, item)
     
     # 3. 新しいトークンを生成（元カードと同じゾーンに）
@@ -76,18 +76,18 @@ def _get_transform_target(act, item):
 
 
 def _move_card_to_exile(card, item):
-    """元カードを ExileZone に移動"""
+    """元カードを Exile に移動"""
     from_zone = card.get("zone")
-    logger.info(f"_move_card_to_exile: Moving card {card['id']} from {from_zone} to ExileZone")
-    card["zone"] = "ExileZone"
-    logger.info(f"_move_card_to_exile: moved card to ExileZone")
+    logger.info(f"_move_card_to_exile: Moving card {card['id']} from {from_zone} to Exile")
+    card["zone"] = "Exile"
+    logger.info(f"_move_card_to_exile: moved card to Exile")
     
     return [{
         "type": "MoveZone",
         "payload": {
             "cardId": card["id"],
             "fromZone": from_zone,
-            "toZone": "ExileZone"
+            "toZone": "Exile"
         }
     }]
 

--- a/helper.py
+++ b/helper.py
@@ -120,7 +120,7 @@ TARGET_ZONES = [
     "Hand",
     "Deck",
     "Graveyard",
-    "ExileZone",
+    "Exile",
     "DamageZone"
 ]
 
@@ -251,11 +251,11 @@ def get_target_cards(src: Dict, action: Dict, item: Dict) -> List[Dict]:
     if target == "AllGraveyard":
         return [c for c in cards if c["zone"] == "Graveyard"]
     if target == "PlayerExileZone":
-        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "ExileZone"]
+        return [c for c in cards if c["ownerId"] == owner and c["zone"] == "Exile"]
     if target == "EnemyExileZone":
-        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "ExileZone"]
+        return [c for c in cards if c["ownerId"] != owner and c["zone"] == "Exile"]
     if target == "AllExileZone":
-        return [c for c in cards if c["zone"] == "ExileZone"]
+        return [c for c in cards if c["zone"] == "Exile"]
     if target == "PlayerDamageZone":
         return [c for c in cards if c["ownerId"] == owner and c["zone"] == "DamageZone"]
     if target == "EnemyDamageZone":

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -456,7 +456,7 @@ def _get_target_zones_from_action(action):
     elif "Graveyard" in target:
         return ["Graveyard"]
     elif "ExileZone" in target:
-        return ["ExileZone"]
+        return ["Exile"]
     elif "DamageZone" in target:
         return ["DamageZone"]
     elif "Deck" in target:

--- a/test_passive_extensions.py
+++ b/test_passive_extensions.py
@@ -8,7 +8,7 @@ def test_zone_constants():
     """対象ゾーンリストの定数定義テスト"""
     expected_zones = [
         "Field", "Environment", "Counter", "Hand", 
-        "Deck", "Graveyard", "ExileZone", "DamageZone"
+        "Deck", "Graveyard", "Exile", "DamageZone"
     ]
     assert TARGET_ZONES == expected_zones
     print("✓ TARGET_ZONES constant defined correctly")

--- a/tests/test_create_token_random.py
+++ b/tests/test_create_token_random.py
@@ -101,7 +101,7 @@ def test_create_token_different_zones():
         ("Graveyard", "Graveyard"),
         ("Environment", "Environment"),
         ("Counter", "Counter"),
-        ("ExileZone", "ExileZone"),
+        ("ExileZone", "Exile"),
         ("DamageZone", "DamageZone"),
         ("UnknownZone", "Field")  # 不明なゾーンはFieldにマップ
     ]

--- a/tests/test_transform_random.py
+++ b/tests/test_transform_random.py
@@ -54,11 +54,11 @@ def test_transform_with_selection_key():
         # 2つのイベントが生成されることを確認（MoveZone + CreateToken）
         assert len(events) == 2
         
-        # 元カードが ExileZone に移動するイベント
+        # 元カードが Exile に移動するイベント
         assert events[0]["type"] == "MoveZone"
         assert events[0]["payload"]["cardId"] == "original_card"
         assert events[0]["payload"]["fromZone"] == "Field"
-        assert events[0]["payload"]["toZone"] == "ExileZone"
+        assert events[0]["payload"]["toZone"] == "Exile"
         
         # 新しいトークンが生成されるイベント
         assert events[1]["type"] == "CreateToken"
@@ -66,8 +66,8 @@ def test_transform_with_selection_key():
         assert events[1]["payload"]["ownerId"] == "player1"
         assert events[1]["payload"]["zone"] == "Field"  # 元カードと同じゾーン
         
-        # 元カードが ExileZone に移動していることを確認
-        assert original_card["zone"] == "ExileZone"
+        # 元カードが Exile に移動していることを確認
+        assert original_card["zone"] == "Exile"
         
         # 新しいトークンが item.cards に追加されていることを確認
         assert len(item["cards"]) == 2
@@ -250,18 +250,18 @@ def test_transform_cocoon_scenario():
         # 2つのイベントが生成されることを確認
         assert len(events) == 2
         
-        # 元の繭カードが ExileZone に移動
+        # 元の繭カードが Exile に移動
         assert events[0]["type"] == "MoveZone"
         assert events[0]["payload"]["cardId"] == "cocoon_card_id"
-        assert events[0]["payload"]["toZone"] == "ExileZone"
+        assert events[0]["payload"]["toZone"] == "Exile"
         
         # 新しいトークンが生成される
         assert events[1]["type"] == "CreateToken"
         assert events[1]["payload"]["baseCardId"] == "token_004"
         assert events[1]["payload"]["zone"] == "Field"
         
-        # 元カードが ExileZone に移動していることを確認
-        assert cocoon_card["zone"] == "ExileZone"
+        # 元カードが Exile に移動していることを確認
+        assert cocoon_card["zone"] == "Exile"
         
         # 新しいトークンが追加されていることを確認
         assert len(item["cards"]) == 2


### PR DESCRIPTION
enum ZoneTypeの定義に合わせて「ExileZone」を「Exile」に統一しました。

## 変更内容

**メインコード:**
- `actions/transform.py`: コメントとコード内の7箇所
- `helper.py`: TARGET_ZONESと関数内の4箇所
- `lambda_function.py`: _get_target_zones_from_action内の1箇所
- `actions/create_token.py`: zone_map内の1箇所
- `action_registry.py`: _zone_map内の1箇所

**テストコード:**
- `test_passive_extensions.py`: expected_zones内の1箇所
- `tests/test_create_token_random.py`: テストケース内の1箇所
- `tests/test_transform_random.py`: テストケース内の6箇所

合計22箇所でZoneTypeが統一され、enum定義に完全対応しました。

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)