### PR TITLE
feat: resolve merge conflict and implement ProcessDamage action

### DIFF
--- a/action_registry.py
+++ b/action_registry.py
@@ -35,6 +35,7 @@ from actions.next_summon_buff import handle_next_summon_buff
 from actions.cost_modifier import handle_cost_modifier
 from actions.set_status import handle_set_status
 from actions.handle_turn_end import handle_turn_end
+from actions.process_damage import handle_process_damage
 
 @register("Draw")
 def _draw(card, act, item, owner_id):
@@ -131,6 +132,10 @@ def _set_status(card, act, item, owner_id):
 @register("TurnEnd")
 def _turn_end(card, act, item, owner_id):
     return handle_turn_end(card, act, item, owner_id)
+
+@register("ProcessDamage")
+def _process_damage(card, act, item, owner_id):
+    return handle_process_damage(card, act, item, owner_id)
 
 # 汎用移動系アクションタイプ → 移動先ゾーン のマッピング
 _zone_map = {

--- a/actions/process_damage.py
+++ b/actions/process_damage.py
@@ -1,0 +1,200 @@
+# actions/process_damage.py
+from helper import fetch_card_masters, resolve_targets, add_status, add_temp_status
+import random
+
+def handle_process_damage(card, act, item, owner_id):
+    """
+    サーバー側ダメージ処理
+    1. デッキトップから指定枚数をダメージゾーンに移動
+    2. TOカードの使用可否選択
+    3. カラー付与（TO使用しない場合）
+    4. 反射ダメージチェイン
+    5. OnDamageトリガー
+    """
+    damage_value = int(act.get("value", 1))
+    target_player_id = act.get("targetPlayerId")
+    
+    if not target_player_id:
+        # デフォルトで敵プレイヤーを対象とする
+        target_player_id = next((p["id"] for p in item["players"] if p["id"] != owner_id), None)
+    
+    if not target_player_id:
+        return []
+    
+    events = []
+    
+    # プレイヤー情報を取得
+    target_player = next((p for p in item["players"] if p["id"] == target_player_id), None)
+    if not target_player:
+        return []
+    
+    # デッキから指定枚数のカードを取得
+    deck_cards = [c for c in item["cards"] if c["zone"] == "Deck" and c["ownerId"] == target_player_id]
+    if len(deck_cards) < damage_value:
+        damage_value = len(deck_cards)  # デッキが足りない場合は可能な限り
+    
+    # デッキトップから指定枚数を取得（シャッフル済みと仮定）
+    damage_cards = deck_cards[:damage_value]
+    
+    # カードマスターデータを取得
+    card_ids = [c["cardId"] for c in damage_cards]
+    card_masters = fetch_card_masters(card_ids)
+    
+    # 1. ダメージゾーンに移動
+    for damage_card in damage_cards:
+        damage_card["zone"] = "DamageZone"
+        events.append({
+            "type": "MoveZone",
+            "payload": {
+                "cardId": damage_card["id"],
+                "fromZone": "Deck",
+                "toZone": "DamageZone"
+            }
+        })
+    
+    # 2. TOカードの処理
+    for damage_card in damage_cards:
+        card_master = card_masters.get(damage_card["cardId"], {})
+        is_to = card_master.get("isTO", False)
+        
+        if is_to:
+            # TOカードの使用可否選択
+            selection_key = f"to_select_{damage_card['id']}"
+            
+            # 選択肢を提供
+            events.append({
+                "type": "SelectOption",
+                "payload": {
+                    "selectionKey": selection_key,
+                    "options": ["use", "not_use"],
+                    "prompt": f"TOカード {card_master.get('name', '不明')} を使用しますか？",
+                    "cardId": damage_card["id"]
+                }
+            })
+            
+            # choiceRequestsに追加（クライアントが選択するまで待機）
+            item.setdefault("choiceRequests", []).append({
+                "requestId": selection_key,
+                "playerId": target_player_id,
+                "cardId": damage_card["id"],
+                "type": "to_selection"
+            })
+            
+        else:
+            # 通常カードの場合はカラー付与
+            available_colors = card_master.get("availableColors", ["Red", "Blue", "Green", "Yellow", "Purple"])
+            assigned_color = random.choice(available_colors)
+            
+            damage_card["assignedColor"] = assigned_color
+            events.append({
+                "type": "AssignColor",
+                "payload": {
+                    "cardId": damage_card["id"],
+                    "color": assigned_color
+                }
+            })
+    
+    # 3. 反射ダメージチェック
+    reflection_events = check_reflection_damage(owner_id, target_player_id, damage_value, item)
+    events.extend(reflection_events)
+    
+    # 4. OnDamageトリガー
+    events.append({
+        "type": "AbilityActivated",
+        "payload": {
+            "trigger": "OnDamage",
+            "targetPlayerId": target_player_id,
+            "damageValue": damage_value,
+            "cardCount": len(damage_cards)
+        }
+    })
+    
+    return events
+
+def check_reflection_damage(attacker_id, defender_id, damage_value, item):
+    """
+    反射ダメージのチェック
+    """
+    events = []
+    
+    # 防御側のフィールドカードでIsChainPainReflectステータスを持つカードを検索
+    field_cards = [c for c in item["cards"] if c["zone"] == "Field" and c["ownerId"] == defender_id]
+    
+    for field_card in field_cards:
+        has_reflect = any(
+            status.get("key") == "IsChainPainReflect" 
+            for status in field_card.get("statuses", [])
+        )
+        
+        if has_reflect:
+            # 反射ダメージを攻撃者に与える
+            events.append({
+                "type": "ReflectionDamage",
+                "payload": {
+                    "sourceCardId": field_card["id"],
+                    "attackerId": attacker_id,
+                    "defenderId": defender_id,
+                    "originalDamage": damage_value
+                }
+            })
+            
+            # 攻撃者に対して追加のProcessDamageを発火
+            events.append({
+                "type": "ProcessDamage",
+                "payload": {
+                    "value": damage_value,
+                    "targetPlayerId": attacker_id,
+                    "isReflection": True
+                }
+            })
+            
+            break  # 1回だけ反射
+    
+    return events
+
+def process_to_selection_result(damage_card, selected_value, item):
+    """
+    TO選択結果の処理
+    """
+    events = []
+    
+    if selected_value == "use":
+        # TO効果を発動
+        card_master = fetch_card_masters([damage_card["cardId"]])[damage_card["cardId"]]
+        to_effect = card_master.get("toEffect", {})
+        
+        events.append({
+            "type": "AbilityActivated",
+            "payload": {
+                "cardId": damage_card["id"],
+                "ability": "TO",
+                "effect": to_effect
+            }
+        })
+        
+    else:
+        # TO使用しない場合はカラー付与
+        card_master = fetch_card_masters([damage_card["cardId"]])[damage_card["cardId"]]
+        available_colors = card_master.get("availableColors", ["Red", "Blue", "Green", "Yellow", "Purple"])
+        assigned_color = random.choice(available_colors)
+        
+        damage_card["assignedColor"] = assigned_color
+        events.append({
+            "type": "AssignColor",
+            "payload": {
+                "cardId": damage_card["id"],
+                "color": assigned_color
+            }
+        })
+    
+    # 選択結果を通知
+    events.append({
+        "type": "SelectOptionResult",
+        "payload": {
+            "cardId": damage_card["id"],
+            "selectedValue": selected_value,
+            "result": "processed"
+        }
+    })
+    
+    return events

--- a/tests/test_process_damage.py
+++ b/tests/test_process_damage.py
@@ -1,0 +1,203 @@
+# tests/test_process_damage.py
+import pytest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from actions.process_damage import handle_process_damage, check_reflection_damage, process_to_selection_result
+
+def test_process_damage_basic():
+    """基本的なダメージ処理のテスト"""
+    # テストデータ
+    card = {"id": "attacker1", "ownerId": "player1"}
+    act = {"value": 2, "targetPlayerId": "player2"}
+    item = {
+        "players": [
+            {"id": "player1", "hp": 20},
+            {"id": "player2", "hp": 20}
+        ],
+        "cards": [
+            {"id": "deck1", "cardId": "card1", "zone": "Deck", "ownerId": "player2"},
+            {"id": "deck2", "cardId": "card2", "zone": "Deck", "ownerId": "player2"},
+            {"id": "deck3", "cardId": "card3", "zone": "Deck", "ownerId": "player2"}
+        ]
+    }
+    owner_id = "player1"
+    
+    # モックカードマスターデータ
+    mock_card_masters = {
+        "card1": {"name": "Test Card 1", "isTO": False, "availableColors": ["Red", "Blue"]},
+        "card2": {"name": "Test Card 2", "isTO": False, "availableColors": ["Green", "Yellow"]}
+    }
+    
+    with patch('actions.process_damage.fetch_card_masters', return_value=mock_card_masters):
+        events = handle_process_damage(card, act, item, owner_id)
+    
+    # 結果検証
+    assert len(events) >= 4  # MoveZone x2 + AssignColor x2 + AbilityActivated
+    
+    # MoveZoneイベントの検証
+    move_events = [e for e in events if e["type"] == "MoveZone"]
+    assert len(move_events) == 2
+    assert move_events[0]["payload"]["fromZone"] == "Deck"
+    assert move_events[0]["payload"]["toZone"] == "DamageZone"
+    
+    # AssignColorイベントの検証
+    assign_color_events = [e for e in events if e["type"] == "AssignColor"]
+    assert len(assign_color_events) == 2
+    
+    # OnDamageトリガーの検証
+    ability_events = [e for e in events if e["type"] == "AbilityActivated"]
+    assert len(ability_events) == 1
+    assert ability_events[0]["payload"]["trigger"] == "OnDamage"
+
+def test_process_damage_with_to_card():
+    """TOカードを含むダメージ処理のテスト"""
+    # テストデータ
+    card = {"id": "attacker1", "ownerId": "player1"}
+    act = {"value": 1, "targetPlayerId": "player2"}
+    item = {
+        "players": [
+            {"id": "player1", "hp": 20},
+            {"id": "player2", "hp": 20}
+        ],
+        "cards": [
+            {"id": "deck1", "cardId": "to_card1", "zone": "Deck", "ownerId": "player2"}
+        ]
+    }
+    owner_id = "player1"
+    
+    # モックカードマスターデータ（TOカード）
+    mock_card_masters = {
+        "to_card1": {"name": "TO Card", "isTO": True, "toEffect": {"type": "heal", "value": 5}}
+    }
+    
+    with patch('actions.process_damage.fetch_card_masters', return_value=mock_card_masters):
+        events = handle_process_damage(card, act, item, owner_id)
+    
+    # 結果検証
+    move_events = [e for e in events if e["type"] == "MoveZone"]
+    select_events = [e for e in events if e["type"] == "SelectOption"]
+    
+    assert len(move_events) == 1
+    assert len(select_events) == 1
+    
+    # SelectOptionイベントの検証
+    select_event = select_events[0]
+    assert select_event["payload"]["options"] == ["use", "not_use"]
+    assert "choiceRequests" in item
+    assert len(item["choiceRequests"]) == 1
+
+def test_process_damage_reflection():
+    """反射ダメージのテスト"""
+    # テストデータ
+    attacker_id = "player1"
+    defender_id = "player2"
+    damage_value = 3
+    item = {
+        "cards": [
+            {
+                "id": "field1",
+                "zone": "Field",
+                "ownerId": "player2",
+                "statuses": [{"key": "IsChainPainReflect", "value": 1}]
+            }
+        ]
+    }
+    
+    events = check_reflection_damage(attacker_id, defender_id, damage_value, item)
+    
+    # 結果検証
+    assert len(events) == 2
+    
+    # ReflectionDamageイベントの検証
+    reflection_events = [e for e in events if e["type"] == "ReflectionDamage"]
+    assert len(reflection_events) == 1
+    assert reflection_events[0]["payload"]["attackerId"] == attacker_id
+    assert reflection_events[0]["payload"]["defenderId"] == defender_id
+    assert reflection_events[0]["payload"]["originalDamage"] == damage_value
+    
+    # ProcessDamageイベントの検証
+    process_events = [e for e in events if e["type"] == "ProcessDamage"]
+    assert len(process_events) == 1
+    assert process_events[0]["payload"]["targetPlayerId"] == attacker_id
+    assert process_events[0]["payload"]["isReflection"] == True
+
+def test_to_selection_result_use():
+    """TO使用選択結果のテスト"""
+    # テストデータ
+    damage_card = {"id": "card1", "cardId": "to_card1"}
+    selected_value = "use"
+    item = {}
+    
+    # モックカードマスターデータ
+    mock_card_masters = {
+        "to_card1": {"name": "TO Card", "isTO": True, "toEffect": {"type": "heal", "value": 5}}
+    }
+    
+    with patch('actions.process_damage.fetch_card_masters', return_value=mock_card_masters):
+        events = process_to_selection_result(damage_card, selected_value, item)
+    
+    # 結果検証
+    assert len(events) == 2
+    
+    # AbilityActivatedイベントの検証
+    ability_events = [e for e in events if e["type"] == "AbilityActivated"]
+    assert len(ability_events) == 1
+    assert ability_events[0]["payload"]["ability"] == "TO"
+    
+    # SelectOptionResultイベントの検証
+    result_events = [e for e in events if e["type"] == "SelectOptionResult"]
+    assert len(result_events) == 1
+    assert result_events[0]["payload"]["selectedValue"] == "use"
+
+def test_to_selection_result_not_use():
+    """TO使用しない選択結果のテスト"""
+    # テストデータ
+    damage_card = {"id": "card1", "cardId": "to_card1"}
+    selected_value = "not_use"
+    item = {}
+    
+    # モックカードマスターデータ
+    mock_card_masters = {
+        "to_card1": {"name": "TO Card", "isTO": True, "availableColors": ["Red", "Blue"]}
+    }
+    
+    with patch('actions.process_damage.fetch_card_masters', return_value=mock_card_masters):
+        events = process_to_selection_result(damage_card, selected_value, item)
+    
+    # 結果検証
+    assert len(events) == 2
+    
+    # AssignColorイベントの検証
+    assign_events = [e for e in events if e["type"] == "AssignColor"]
+    assert len(assign_events) == 1
+    assert assign_events[0]["payload"]["color"] in ["Red", "Blue"]
+    
+    # SelectOptionResultイベントの検証
+    result_events = [e for e in events if e["type"] == "SelectOptionResult"]
+    assert len(result_events) == 1
+    assert result_events[0]["payload"]["selectedValue"] == "not_use"
+
+def test_process_damage_no_reflection():
+    """反射ダメージなしのテスト"""
+    # テストデータ
+    attacker_id = "player1"
+    defender_id = "player2"
+    damage_value = 3
+    item = {
+        "cards": [
+            {
+                "id": "field1",
+                "zone": "Field",
+                "ownerId": "player2",
+                "statuses": [{"key": "SomeOtherStatus", "value": 1}]
+            }
+        ]
+    }
+    
+    events = check_reflection_damage(attacker_id, defender_id, damage_value, item)
+    
+    # 結果検証：反射ダメージはなし
+    assert len(events) == 0


### PR DESCRIPTION
Issue #38のマージコンフリクトを解決し、ProcessDamageアクションを実装しました。

## 変更内容
- ✅ ProcessDamageアクションの実装
- ✅ TurnEndとProcessDamageの両方をaction_registry.pyに登録
- ✅ 包括的なユニットテストの作成

## 実装機能
1. デッキからダメージゾーンへのカード移動
2. TOカード使用可否の選択処理
3. カラー付与処理
4. 反射ダメージチェイン
5. OnDamageトリガー処理

🤖 Generated with [Claude Code](https://claude.ai/code)